### PR TITLE
Repro for eslint-plugin-astro/no-unused-css-selector

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,37 +1,20 @@
 ---
-import fox from "~/assets/pexels-erik-karits-3722722.jpg";
 import BaseLayout from "~/layouts/BaseLayout.astro";
-import { ThemeSelector } from "~/components/ThemeSelector";
-import { getImage } from "astro:assets";
 
-const [foxPNG, foxAVIF] = await Promise.all([
-  getImage({ src: fox, width: 640, format: "png" }),
-  getImage({ src: fox, width: 640, format: "avif" })
-]);
+const Heading = "h2" as const;
 ---
 
 <BaseLayout title="Astro" description="Astro Preact Template">
   <h1>Astro</h1>
-  <h2>Theme Handler</h2>
-  You can edit this component in
-  <code>./src/components/ThemeSelector.tsx</code>.
-  <ThemeSelector client:only="preact" />
-  <h2>Picture test</h2>
-  <picture>
-    <source type="image/avif" srcset={foxAVIF.src} />
-    <img
-      src={foxPNG.src}
-      width={foxPNG.attributes.width}
-      height={foxPNG.attributes.height}
-      alt="Brown Fox on Tree Stump by Erik Karits"
-    />
-  </picture>
+  <Heading class="heading">Reproduction Example</Heading>
 </BaseLayout>
 
 <style>
-  picture,
-  img {
-    max-width: 100%;
-    height: auto;
+  .heading {
+    display: block;
+    border-bottom: 1px solid var(--highlight);
+    padding: 1rem;
+    margin: 0px;
+    font-size: 1.5rem;
   }
 </style>


### PR DESCRIPTION
For some reason cannot open issues on the repository for the plugin, so here's the issue text:

## What did you do

<details>
<summary>Configuration</summary>

See https://github.com/Mitsunee/astro-template/blob/main/eslint.config.js

</details>

```astro
---
interface Props {
  headingEl?: `h${2 | 3 | 4}`;
}

const Heading = Astro.props.headingEl || ("h2" as const);
---
<Heading class="heading"><slot /></Heading>

<style>
.heading {
    display: block;
    border-bottom: 1px solid var(--highlight);
    padding: 1rem;
    margin: 0px;
    font-size: 1.5rem;
}
</style>
```

## What did you expect to happen?

The `.heading` class name is recognized as used

## What actually happened?

Got this warning: "Unused CSS selector `.heading`" 

## Link to repo

See https://github.com/Mitsunee/astro-testing/blob/2025-02-04-no-unused-css-selector-bug/src/pages/index.astro in this PR